### PR TITLE
super-linter: Allow `br` inside Markdown docs

### DIFF
--- a/super-linter/config/config.json
+++ b/super-linter/config/config.json
@@ -5,7 +5,8 @@
 	"MD029": { "style": "one" },
 	"MD033": {
         "allowed_elements": [
-          "img"
+          "img",
+	  "br"
         ]
     },
 	"MD035": false,


### PR DESCRIPTION
Adding a newline inside a Markdown table is impossible without `<br>`. These kinds of elements are, however, forbidden my markdownlinter, as they represent a form of inline HTML.

Add rule inside general config to ignore this error.

Related-To: security-summer-school/essentials#42