### PR TITLE
spellcheck: Add wordlists to configuration

### DIFF
--- a/spellcheck/config/spellcheck.yml
+++ b/spellcheck/config/spellcheck.yml
@@ -3,6 +3,8 @@ matrix:
   aspell:
     lang: en
   dictionary:
+    wordlists:
+    - .wordlist.txt
     encoding: utf-8
   pipeline:
   - pyspelling.filters.markdown:


### PR DESCRIPTION
Add the `wordlists` item to the spellcheck configuration. Repositories can then store the `.wordlist.txt` file with custom words to be ignored by spellcheck.