### PR TITLE
spellcheck: Check only the files amended in PR

### DIFF
--- a/spellcheck/action.yml
+++ b/spellcheck/action.yml
@@ -12,6 +12,13 @@ runs:
     - name: Checkout Code
       uses: actions/checkout@v3
 
+    - name: Get Changed Files
+      id: changed-files
+      uses: tj-actions/changed-files@v37
+      with:
+        files: |
+          *.md
+
     - name: Setup Environment
       shell: bash
       run: |
@@ -23,4 +30,5 @@ runs:
       uses: rojopolis/spellcheck-github-actions@v0
       with:
         config_path: .spellcheck.yml
+        source_files: "${{ steps.changed-files.outputs.all_changed_and_modified_files }}"
         task_name: Markdown


### PR DESCRIPTION
Previously the spellcheck action linted the whole codebase. This made the output cluttered and unmanageable.
We overwrite the source files with the result of [another action](https://github.com/marketplace/actions/changed-files) which gets the changed files from a PR.

Mock PR: https://github.com/mariasfiraiala/essentials/actions/runs/5919293856/job/16049427316?pr=3

Mock action: https://github.com/mariasfiraiala/actions/tree/main/spellcheck