### PR TITLE
`super-linter`: Add configuration for `textlinter`

### DIFF
--- a/super-linter/.textlintrc
+++ b/super-linter/.textlintrc
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "terminology": {
+      // Load default terms (see terms.jsonc in the repository)
+      "defaultTerms": true,
+      "exclude": [
+        "web[- ]?site(s)?",
+        "build system(s)?",
+        "e-mail(s)?",
+        "front[- ]end(s)?"
+      ]
+    }
+  }
+}

--- a/super-linter/action.yml
+++ b/super-linter/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
-    
+
     - name: Setup Environment
       shell: bash
       run: |

--- a/super-linter/action.yml
+++ b/super-linter/action.yml
@@ -25,8 +25,8 @@ runs:
         wget -O config-action.zip -q https://github.com/security-summer-school/actions/archive/refs/heads/main.zip
         unzip -q config-action.zip -d config-action
         mkdir .linter-config
-        mv config-action/actions-main/super-linter/* .linter-config
-        mv config-action/actions-main/super-linter/.jscpd.json .linter-config
+        mv config-action/actions-main/super-linter/* .linter-config/
+        mv config-action/actions-main/super-linter/.jscpd.json .linter-config/
 
     - name: Lint Code Base
       uses: github/super-linter/slim@v4

--- a/super-linter/action.yml
+++ b/super-linter/action.yml
@@ -27,6 +27,7 @@ runs:
         mkdir .linter-config
         mv config-action/actions-main/super-linter/* .linter-config/
         mv config-action/actions-main/super-linter/.jscpd.json .linter-config/
+        mv config-action/actions-main/super-linter/.textlintrc .linter-config/
 
     - name: Lint Code Base
       uses: github/super-linter/slim@v4


### PR DESCRIPTION
Add `.textlintrc` configuration file for textlinter. It allows certain common words that `textlinter` (the terminology plugin) would complain about.