### PR TITLE
`super-linter`: Disable MD041

### DIFF
--- a/super-linter/config/config.json
+++ b/super-linter/config/config.json
@@ -10,6 +10,7 @@
     ]
   },
   "MD035": false,
+  "MD041": false,
   "MD046": { "style": "fenced" },
   "MD048": { "style": "backtick" },
   "line-length": false,

--- a/super-linter/config/config.json
+++ b/super-linter/config/config.json
@@ -1,17 +1,17 @@
 {
-	"default": true,
-	"MD004": false,
-	"MD024": false,
-	"MD029": { "style": "one" },
-	"MD033": {
-        "allowed_elements": [
-          "img",
-	  "br"
-        ]
-    },
-	"MD035": false,
-	"MD046": { "style": "fenced" },
-	"MD048": { "style": "backtick" },
-	"line-length": false,
-	"no-hard-tabs": false
+  "default": true,
+  "MD004": false,
+  "MD024": false,
+  "MD029": { "style": "one" },
+  "MD033": {
+    "allowed_elements": [
+      "img",
+      "br"
+    ]
+  },
+  "MD035": false,
+  "MD046": { "style": "fenced" },
+  "MD048": { "style": "backtick" },
+  "line-length": false,
+  "no-hard-tabs": false
 }


### PR DESCRIPTION
MD041 is a `markdownlint` rule that checks that all files start with a heading rule.
    
Disable it, as there may be cases where files don't start with a heading rule, or is not a 1st level (h1) heading rules.